### PR TITLE
Shashank/fixed a broken link

### DIFF
--- a/_includes/token-input.html
+++ b/_includes/token-input.html
@@ -3,5 +3,5 @@
         <input type="text" id="api-token" placeholder="API Token">
         <button id="send-auth-manually-btn">Authenticate</button>
     </div>
-    <a target=tokeninput href="https://www.binary.com/user/api_token">Get your API token</a>    
+    <a target=tokeninput href="https://www.binary.com/user/api_tokenws">Get your API token</a>    
 </fieldset>


### PR DESCRIPTION
We have updated our api token page from https://www.binary.com/user/api_token to https://www.binary.com/user/api_tokenws
 but our developers.binary.com static page was still pointing to the old one which will send a user to a broken link. 