### PR TITLE
Correction for ticks_history response msg_type

### DIFF
--- a/config/v3/ticks_history/receive.json
+++ b/config/v3/ticks_history/receive.json
@@ -65,8 +65,8 @@
       "description": "Array of OHLC (open/high/low/close) price values for the given time (only for style='candles')"
     },
     "msg_type": {
-      "type": "string",
-      "description": "style",
+      "enum": ["candles", "history"],
+      "description": "Will read 'candles' if you requested 'candles', else 'history'",
       "required": 1
     },
     "req_id": {


### PR DESCRIPTION
If you request "ticks" the msg_type will be "history" not "ticks".