### PR TITLE
Distinguish production env by baseurl eq /websockets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 # Site settings
 title: Binary.com Developers
-baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://developers.binary.com"
 twitter_username: binarydotcom
 github_username:  binary-com

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html>
 
-  {% assign base_url = '/websockets' %}
-  {% assign branch = '' %}
-  {% if site.baseurl contains base_url %}
-    {% assign branch = base_url %}
+  {% assign branch = site.baseurl %}
+  {% if site.baseurl == '/websockets' %}
+    {% assign branch = '' %}
   {% endif %}
 
   {% include head.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,10 +2,9 @@
 layout: default
 ---
 
-{% assign base_url = '/websockets' %}
-{% assign branch = '' %}
-{% if site.baseurl contains base_url %}
-    {% assign branch = base_url %}
+{% assign branch = site.baseurl %}
+{% if site.baseurl == '/websockets' %}
+  {% assign branch = '' %}
 {% endif %}
 
 {% include mobile-page-selector.html %}


### PR DESCRIPTION
After this is merged, developers can push to their own fork by renaming their repo to something not equal to `websockets` preferably `websockets-dev` (e.g. https://github.com/aminmarashi/websockets-dev).
It can be done in the fork settings:
<img width="665" alt="screen shot 2017-07-26 at 2 09 48 pm" src="https://user-images.githubusercontent.com/6560964/28606936-24395ef0-720c-11e7-8862-4ead005d9212.png">
