### PR TITLE
Distinguish production env by baseurl eq /websockets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 # Site settings
 title: Binary.com Developers
-baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://developers.binary.com"
 twitter_username: binarydotcom
 github_username:  binary-com

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html>
 
-  {% assign base_url = '/websockets' %}
-  {% assign branch = '' %}
-  {% if site.baseurl contains base_url %}
-    {% assign branch = base_url %}
+  {% assign branch = site.baseurl %}
+  {% if site.baseurl == '/websockets' %}
+    {% assign branch = '' %}
   {% endif %}
 
   {% include head.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,10 +2,9 @@
 layout: default
 ---
 
-{% assign base_url = '/websockets' %}
-{% assign branch = '' %}
-{% if site.baseurl contains base_url %}
-    {% assign branch = base_url %}
+{% assign branch = site.baseurl %}
+{% if site.baseurl == '/websockets' %}
+  {% assign branch = '' %}
 {% endif %}
 
 {% include mobile-page-selector.html %}

--- a/code.js
+++ b/code.js
@@ -10,20 +10,13 @@ var defaultApiUrl = 'wss://ws.binaryws.com/websockets/v3';
 var appId = localStorage.getItem('appId') || defaultAppId;
 var apiUrl = localStorage.getItem('apiUrl') || defaultApiUrl;
 var langCode = 'en';
-var pathname = document.location.pathname;
-// handle deploying to forks as well as production route
-pathname = /\.github\.io$/i.test(window.location.hostname) ? 'websockets/' : '';
 
-var getPath = function(path) {
-    return pathname + path;
-};
-
-require([getPath("docson/docson"), getPath("lib/jquery"), getPath("lib/select2.min")], function(docson) {
+require(["docson/docson", "lib/jquery", "lib/select2.min"], function(docson) {
 
     var api,
         $console = $('#playground-console');
 
-    docson.templateBaseUrl = '/' + getPath('docson');
+    docson.templateBaseUrl = '/docson';
 
     $('#conn-error').hide();
     $('#connected').hide();
@@ -346,7 +339,7 @@ require([getPath("docson/docson"), getPath("lib/jquery"), getPath("lib/select2.m
     $('#api-call-selector').select2().on('change', function() {
         var verStr = 'v3',
             apiStr = $('#api-call-selector').val(),
-            urlPath = '/' + getPath('config/' + verStr + '/' + apiStr + '/'),
+            urlPath = '/config/' + verStr + '/' + apiStr + '/',
             requestSchemaUrl = urlPath + 'send.json',
             responseSchemaUrl = urlPath + 'receive.json',
             exampleJsonUrl = urlPath + 'example.json';

--- a/code.js
+++ b/code.js
@@ -1,5 +1,13 @@
+function isProduction(url) {
+    return url && url.indexOf('developers.binary.com') > 0;
+}
+
+function getBaseUrl(url) {
+    return (isProduction('' + url) ? '' : '/' + url.split('/')[3]) + '/';
+}
+
 require.config({
-    baseUrl: '/'
+    baseUrl: getBaseUrl(document.location.href),
 });
 
 var LiveApi = window['binary-live-api'].LiveApi;

--- a/docson/docson.js
+++ b/docson/docson.js
@@ -15,17 +15,10 @@
  */
 
 var docson = docson || {};
-var pathname = document.location.pathname;
-// handle deploying to forks as well as production route
-pathname = /\.github\.io$/i.test(window.location.hostname) ? 'websockets/' : '';
 
-var getPath = function(path) {
-    return pathname + path;
-};
+docson.templateBaseUrl="templates";
 
-docson.templateBaseUrl= getPath("templates");
-
-define([getPath("lib/jquery"), getPath("lib/handlebars"), getPath("lib/highlight"), getPath("lib/jsonpointer"), getPath("lib/marked"), getPath("lib/traverse")], function(jquery, handlebars, highlight, jsonpointer, marked) {
+define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib/marked", "lib/traverse"], function(jquery, handlebars, highlight, jsonpointer, marked) {
 
     var ready = $.Deferred();
     var boxTemplate;


### PR DESCRIPTION
After this is merged, developers can push to their own fork by renaming their repo to something not equal to `websockets` preferably `websockets-dev` (e.g. https://github.com/aminmarashi/websockets-dev).
It can be done in the fork settings:
<img width="665" alt="screen shot 2017-07-26 at 2 09 48 pm" src="https://user-images.githubusercontent.com/6560964/28606936-24395ef0-720c-11e7-8862-4ead005d9212.png">
