### PR TITLE
Document the `website_status` API call

### DIFF
--- a/_includes/examples/website_status.js
+++ b/_includes/examples/website_status.js
@@ -1,0 +1,17 @@
+const WebSocket = require('ws');
+const ws = new WebSocket('wss://ws.binaryws.com/websockets/v3?l=EN&app_id=1089');
+
+ws.on('open', function open() {
+    ws.send(JSON.stringify({
+        website_status: 1,
+        subscribe: 1
+    }));
+});
+
+ws.on('message', function incoming(data) {
+    data = JSON.parse(data);
+    console.log('website status: %s', data.website_status.site_status);
+    if (data.website_status.message) {
+        console.log('status message: %s', data.website_status.message);
+    }
+});

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -8,6 +8,7 @@
         <li><a href="{{ branch }}/guide/">API guide</a></li>
         <li><a href="{{ branch }}/faq/">FAQ</a></li>
         <li><a href="{{ branch }}/copytrading/">Copy trading facilities</a></li>
+        <li><a href="{{ branch}}/server-status/">Server status updates</a></li>
         <li><a href="https://binary.vanillacommunity.com" target=_blank>Dev forum</a></li>
         <li><a href="{{ branch }}/schemas/">JSON Schemas</a></li>
         <li><a href="{{ branch }}/open-source/">Open source</a></li>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -8,7 +8,7 @@
         <li><a href="{{ branch }}/guide/">API guide</a></li>
         <li><a href="{{ branch }}/faq/">FAQ</a></li>
         <li><a href="{{ branch }}/copytrading/">Copy trading facilities</a></li>
-        <li><a href="{{ branch}}/server-status/">Server status updates</a></li>
+        <li><a href="{{ branch }}/server-status/">Server status updates</a></li>
         <li><a href="https://binary.vanillacommunity.com" target=_blank>Dev forum</a></li>
         <li><a href="{{ branch }}/schemas/">JSON Schemas</a></li>
         <li><a href="{{ branch }}/open-source/">Open source</a></li>

--- a/_pages/guide.html
+++ b/_pages/guide.html
@@ -63,6 +63,7 @@ There are 2 ways to do client authentication:</p>
 <ul class="bullet">
     <li>To keep the connection alive, use <a href="/api#ping"><code>ping</code></a></li>
     <li>You can get the server time with <a href="/api#time"><code>time</code></a></li>
+    <li>You can also get the status of the website with <a href="/api#website_status"><code>website_status</code></a></li>
 </ul>
 <h2>Streams</h2>
 <p><strong>Note</strong>: Certain functions generate streams (e.g. <a href="/api#ticks"><code>ticks</code></a>) whilst other functions do not. Please use <a href="/api#forget"><code>forget</code></a> to cancel an outstanding stream.</p>

--- a/_pages/server-status.html
+++ b/_pages/server-status.html
@@ -8,7 +8,7 @@ permalink: server-status/
 
 <h2>What is it?</h2>
 
-<p>The API provide a way to let clients check on whether the website is online or not through the <a href="https://developers.binary.com/api/#website_status">website status</a> call.</p>
+<p>The API provides a way to let clients check on whether the website is online or not through the <a href="https://developers.binary.com/api/#website_status">website status</a> call.</p>
 
 <h2>Subscribing to server status notifications</h2>
 

--- a/_pages/server-status.html
+++ b/_pages/server-status.html
@@ -1,0 +1,17 @@
+---
+layout: page
+title: "Server status updates"
+permalink: server-status/
+---
+
+<h1 class="post-title">{{ page.title }}</h1>
+
+<h2>What is it?</h2>
+
+<p>The API provide a way to let clients check on whether the website is online or not through the <a href="https://developers.binary.com/api/#website_status">website status</a> call.</p>
+
+<h2>Subscribing to server status notifications</h2>
+
+<p>Here is a JavaScript code snippet that opens a websocket and makes a subscription for server status notifications.  On receipt of a message, it emits the website status as well a message about the status, if available:</p>
+
+<pre data-language="js">{% include examples/website_status.js %}</pre>


### PR DESCRIPTION
This adds some brief documentation on how to use the WebSocket API to
get server status notifications from Binary.com.