### PR TITLE
:lipstick: fix display of JavaScript server-status example

### DIFF
--- a/_pages/server-status.html
+++ b/_pages/server-status.html
@@ -14,4 +14,4 @@ permalink: server-status/
 
 <p>Here is a JavaScript code snippet that opens a websocket and makes a subscription for server status notifications.  On receipt of a message, it emits the website status as well a message about the status, if available:</p>
 
-<pre data-language="js">{% include examples/website_status.js %}</pre>
+<pre data-language="javascript">{% include examples/website_status.js %}</pre>


### PR DESCRIPTION
Currently the block gets hidden because showDemoForLanguage() in code.js looks for `javascript`, not `js`.