### PR TITLE
Rename /server-status to /server-status-updates

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -8,7 +8,7 @@
         <li><a href="{{ branch }}/guide/">API guide</a></li>
         <li><a href="{{ branch }}/faq/">FAQ</a></li>
         <li><a href="{{ branch }}/copytrading/">Copy trading facilities</a></li>
-        <li><a href="{{ branch }}/server-status/">Server status updates</a></li>
+        <li><a href="{{ branch }}/server-status-updates/">Server status updates</a></li>
         <li><a href="https://binary.vanillacommunity.com" target=_blank>Dev forum</a></li>
         <li><a href="{{ branch }}/schemas/">JSON Schemas</a></li>
         <li><a href="{{ branch }}/open-source/">Open source</a></li>

--- a/_pages/server-status-updates.html
+++ b/_pages/server-status-updates.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Server status updates"
-permalink: server-status/
+permalink: server-status-updates/
 ---
 
 <h1 class="post-title">{{ page.title }}</h1>


### PR DESCRIPTION
CloudFlare masks/checks on `/server-status`, which leads to a "Sorry, you have been blocked" message.  Thus, rename to avoid causing confusion.