### PR TITLE
Update PHP Sample Code

### DIFF
--- a/_includes/demos/php.php
+++ b/_includes/demos/php.php
@@ -1,21 +1,7 @@
-require_once("vendor/autoload.php");
+use WebSocket\Client;
+use Illuminate\Support\Facades\Log;
 
-$loop = \React\EventLoop\Factory::create();
-
-$logger = new \Zend\Log\Logger();
-$writer = new Zend\Log\Writer\Stream("php://output");
-$logger->addWriter($writer);
-
-$client = new \Devristo\Phpws\Client\WebSocket("wss://ws.binaryws.com/websockets/v3?app_id=1089", $loop, $logger);
-
-$client->on("connect", function($headers) use ($client, $logger){
-    $logger->notice("connected!");
-    $client->send("{\"ticks\":\"R_100\"}");
-});
-
-$client->on("message", function($message) use ($client, $logger){
-    $logger->notice("ticks update: ".$message->getData());
-});
-
-$client->open();
-$loop->run();
+$client = new Client("wss://ws.binaryws.com/websockets/v3?app_id=1089");
+$request = (object) ['ticks' => 'R_100'] ;
+$client->send(json_encode($request));
+Log::info("ticks update: ". $client->receive());


### PR DESCRIPTION
`devristo/phpws` is not maintained anymore and caused an error on PHP 7 + Laravel when it is installed via composer. (See image below for proof)

Better use `textalk/websocket`. Simpler to use, support PHP 7, and available in Laravel.

P.S 
I made replacement on log. You can still use Zend for the log but decided to use Laravel's log as I am working in Laravel project. 
If you want to still use Zend, just replace
`Log::info("ticks update: ". $client->receive());`
with
` $logger->notice("ticks update: ".$client->receive());`

![image](https://user-images.githubusercontent.com/8667834/61558987-c941f180-aa92-11e9-8671-f71480b70aba.png)


