### PR TITLE
Use circleci/ruby:2.7-buster image to fix apt-get update error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,14 +132,14 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7-buster
     steps:
       - git_checkout_from_cache
       - bundle_install
       - build
   release_production:
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7-buster
     steps:
       - git_checkout_from_cache
       - bundle_install
@@ -149,7 +149,7 @@ jobs:
       - notify_slack
   release_aws_production:
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7-buster
     steps:
       - git_checkout_from_cache
       - bundle_install


### PR DESCRIPTION
debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'

Signed-off-by: Afshin Paydar <afshin.paydar@binary.com>