### PR TITLE
Cloudflare pages: treat all binary.com URLs as production ones

### DIFF
--- a/code.js
+++ b/code.js
@@ -502,7 +502,7 @@ function setEndpoint(server_url, app_id, brand) {
 // ===== General Functions =====
 // -----------------------------
 function isProduction(url) {
-    return url && /(developers\.binary\.com|binary\.sx)/i.test(url);
+    return url && /(binary\.com|binary\.sx|pages\.dev)/i.test(url);
 }
 
 function isLocal(url) {


### PR DESCRIPTION
# Changes
- There is a subtle bug in `getBaseURL` function which seems working for production/local or GitHub pages URLs format (not all of them) but not for non production URLs without subdirectory. Relax the regex so that `docson` will be able to correctly find the schema.