### PR TITLE
Correct some false (in 2022) sentences

### DIFF
--- a/_pages/careers.html
+++ b/_pages/careers.html
@@ -6,9 +6,9 @@ permalink: careers/
 <h1>Careers</h1>
 
 <p>
-    We are expanding rapidly and are constantly on the lookout for talented software engineers to join our team. The best way to pre-qualify for a job is to submit a useful pull-request to any of our open-source projects.
+    We are expanding rapidly and are constantly on the lookout for talented software engineers to join our team. 
 </p>
 
 <p>
-     <a href="https://www.binary.com/en/careers.html" target="_blank">Learn more</a> about working with Binary.com.
+     <a href="https://deriv.com/careers/" target="_blank">Learn more</a> about working with Binary.com.
 </p>

--- a/_pages/open-source.html
+++ b/_pages/open-source.html
@@ -19,9 +19,6 @@ permalink: open-source/
             <a href="https://github.com/binary-com/binary-static" target="_blank">binary-static</a> – Binary.com website
         </li>
         <li>
-            <a href="https://github.com/binary-com/mobile" target="_blank">mobile</a> – Binary.com mobile app for Android and iOS
-        </li>
-        <li>
             <a href="https://github.com/binary-com/webtrader" target="_blank">webtrader</a> – a desktop application.
             See <a target=_blank href="https://webtrader.binary.com" target="_blank">Binary Webtrader</a>
         </li>
@@ -60,6 +57,3 @@ permalink: open-source/
     </ul>
 </p>
 
-<p>
-    Binary.com's open-source projects are typically published via the <a href="https://pages.github.com">Github Pages</a> service.
-</p>


### PR DESCRIPTION
# Changes
- Delete `mobile` (repo archived)
- Our websites are not served anymore by gh-pages
- Do not advise people to open pull request as a way to apply
- Directly link to new careers link